### PR TITLE
BULDO-43: switch to ruff for ci and add pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.11"
 
-      - name: Install dependencies
-        run: pip install flake8
+      - name: Install ruff
+        run: pip install ruff
 
-      - name: Run linter
-        run: flake8 . --exclude=.venv,target,dbt_packages,logs
+      - name: Run ruff
+        run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.ruff]
+line-length = 79
+target-version = "py311"
+
+exclude = [
+    ".venv",
+    "target",
+    "dbt_packages",
+    "logs",
+]
+
+[tool.ruff.lint]
+
+select = ["E", "F", "I", "B", "UP"]
+
+ignore = ["E501"]


### PR DESCRIPTION
This PR switches linter from flake8 to ruff and add pyproject required.