### PR TITLE
BULDO-71: seperate Open Meteo data from forecast data

### DIFF
--- a/infra_platform/pipelines/ingestion/openaq_spark_ingest.py
+++ b/infra_platform/pipelines/ingestion/openaq_spark_ingest.py
@@ -124,7 +124,7 @@ def fetch_sensor_data(sensor_info):
     print(f"Fetching data for sensor {sid} ({pname}) at {loc_name}")
 
     utc_now = datetime.datetime.now(datetime.UTC)
-    date_from = (utc_now - datetime.timedelta(days=1)).isoformat()
+    date_from = (utc_now - datetime.timedelta(hours=1)).isoformat()
 
     try:
         resp = requests.get(

--- a/infra_platform/pipelines/loading/open_meteo_duckdb_loader.py
+++ b/infra_platform/pipelines/loading/open_meteo_duckdb_loader.py
@@ -12,6 +12,16 @@ OPEN_METEO_SCHEMA = {
     "windspeed_10m": "DOUBLE",
 }
 
+OPEN_METEO_FORECAST_SCHEMA = {
+    "time": "TIMESTAMP",
+    "time_cet": "TIMESTAMP",
+    "temperature_2m": "DOUBLE",
+    "precipitation": "DOUBLE",
+    "precipitation_probability": "DOUBLE",
+    "visibility": "DOUBLE",
+    "windspeed_10m": "DOUBLE",
+}
+
 
 def get_open_meteo_loader():
     config = {
@@ -19,5 +29,15 @@ def get_open_meteo_loader():
         "bucket": os.getenv("MINIO_BUCKET", "bronze"),
         "prefix": "openmeteo",
         "schema": OPEN_METEO_SCHEMA,
+    }
+    return BaseLoader(config)
+
+
+def get_open_meteo_forecast_loader():
+    config = {
+        "table_name": "raw.raw_open_meteo_forecast",
+        "bucket": os.getenv("MINIO_BUCKET", "bronze"),
+        "prefix": "openmeteo_forecast",
+        "schema": OPEN_METEO_FORECAST_SCHEMA,
     }
     return BaseLoader(config)


### PR DESCRIPTION
This PR is a fix to not load future data into open_meteo data seperating 2 tasks and 2 tables for forecast.